### PR TITLE
修复 url 中带有引号时生成出错问题

### DIFF
--- a/gulp-make-css-url-version/index.js
+++ b/gulp-make-css-url-version/index.js
@@ -70,6 +70,7 @@ module.exports = function (options) {
         html = html.replace(/url\("?([^\)"]+)"?\)/g, function (str, url) {
 
             url = url.replace(/\?[\s\S]*$/, "").trim();
+            url = url.replace(/['"]*/g, "");
 
             if (url.indexOf("base64,") > -1 || url.indexOf("http://") > -1 || url.indexOf("/") == 0) {
                 return str;


### PR DESCRIPTION
示例(Less URLs)：
@images: "../img";
body{background: url("@{images}/white-sand.png");}

修正前：body{background:url("../img/white-sand.png"?v=2015-01-07);}
修正后：body{background:url(../img/white-sand.png?v=2015-01-07);}