### PR TITLE
修复url 为“about:blank” （用于IE6固定定位"抖动"bug）

### DIFF
--- a/gulp-make-css-url-version/index.js
+++ b/gulp-make-css-url-version/index.js
@@ -72,7 +72,7 @@ module.exports = function (options) {
             url = url.replace(/\?[\s\S]*$/, "").trim();
             url = url.replace(/['"]*/g, "");
 
-            if (url.indexOf("base64,") > -1 || url.indexOf("http://") > -1 || url.indexOf("/") == 0) {
+            if (url.indexOf("base64,") > -1 || url.indexOf("about:blank") > -1 || url.indexOf("http://") > -1 || url.indexOf("/") == 0) {
                 return str;
             }
 


### PR DESCRIPTION
详见：CSS，实现IE6固定定位及解决"抖动"的原理
http://www.cnblogs.com/slowsoul/archive/2013/05/31/3110135.html