### PR TITLE
Fix url checker, added assetsDir option

### DIFF
--- a/gulp-make-css-url-version/README.md
+++ b/gulp-make-css-url-version/README.md
@@ -34,6 +34,20 @@ gulp.task('stylesheets', function() {
 });
 ```
 
+assetsDir: specify the public directory for correct MD5 calculation in some specific cases
+
+```js
+var makeUrlVer = require('gulp-make-css-url-version');
+
+gulp.task('stylesheets', function() {
+    gulp.src('css/*.css')
+        .pipe(makeUrlVer({
+            assetsDir: __dirname + '/public'
+        }))
+        .pipe(gulp.dest('dist'))
+});
+```
+
 ## Example
 
 ### before: index.css

--- a/gulp-make-css-url-version/index.js
+++ b/gulp-make-css-url-version/index.js
@@ -72,7 +72,7 @@ module.exports = function (options) {
             url = url.replace(/\?[\s\S]*$/, "").trim();
             url = url.replace(/['"]*/g, "");
 
-            if (url.indexOf("base64,") > -1 || url.indexOf("about:blank") > -1 || url.indexOf("http://") > -1 || url.indexOf("/") == 0) {
+            if (url.indexOf("base64,") > -1 || url.indexOf("about:blank") > -1 || url.indexOf("http://") > -1 || url === '/') {
                 return str;
             }
 
@@ -84,7 +84,13 @@ module.exports = function (options) {
             }
 
             //use md5
-            var imageFilePath = path.resolve(path.dirname(file.path), url.replace(/#[\s\S]*$/,''));
+            var safeUrl = url.replace(/#[\s\S]*$/,'');
+            var imageFilePath;
+            if (options.assetsDir) {
+                imageFilePath = path.join(options.assetsDir, safeUrl);
+            } else {
+                imageFilePath = path.resolve(path.dirname(file.path), safeUrl);
+            }
 
             var tempKey = Math.random().toString();
             var readFile = Q.denodeify(fs.readFile);


### PR DESCRIPTION
1. Fixed URL checker, it has ignored all links that begin with "/"
2. Added new option "assetsDir", that specifies the directory with static assets (in server public directory). It helpful, when my URLs are relative to a "public" directory, not to the directory where CSS files are placed. The Script can correctly find a path to the file and calculate md5.
