### PR TITLE
Updated date format to full time

### DIFF
--- a/gulp-make-css-url-version/index.js
+++ b/gulp-make-css-url-version/index.js
@@ -76,7 +76,7 @@ module.exports = function (options) {
                 return str;
             }
 
-            var format = options.format || "yyyy-MM-dd";
+            var format = options.format || "yyyyMMddhmmss";
 
             //use date as the version
             if (options.useDate) {


### PR DESCRIPTION
This should fix caching issue, as previous format does not take into account time. This will ensure that the latest version of a file is fetched on refresh.

Previous outputted timestamp - src:url(myfile.jpg?v=2017-08-09); 
Updated outputted timestamp - src:url(myfile.jpg?v=2017080993403);